### PR TITLE
Ignore trivial rownames when assigning protein accessions

### DIFF
--- a/R/ratio-methods.R
+++ b/R/ratio-methods.R
@@ -1131,8 +1131,8 @@ combn.protein.tbl <- function(cmbn, reverse=FALSE, ...) {
     else
      df <- data.frame(r,stringsAsFactors=FALSE)
 
-    if (!is.null(rownames(r))) 
-      df[,'ac']<- rownames(df)
+    if (!is.null(rownames(r)) && any(rownames(r) != as.character(seq_len(nrow(r))))) 
+      df[,'ac']<- rownames(r)
     rownames(df) <- NULL
 
     df$r1 <- x[1]; df$r2 <- x[2]


### PR DESCRIPTION
This fixes a situation of setting protein accessions to rownames of protein table when these rownames are just "1","2",...
However, I haven't further investigated why such rownames occur, maybe the real fix should be applied somewhere before or maybe such rownames behaviour is R version-specific.
