### PR TITLE
Default behavior when no protein groups are provided for correct.peptide.ratios()

### DIFF
--- a/R/report-utils.R
+++ b/R/report-utils.R
@@ -609,7 +609,13 @@ property <- function(x, envir, null.ok=TRUE,class=NULL) {
 
     if (!is.null(property('correct.peptide.ratios.with',properties.env))) {
       protein.quant.tbl <- .get.or.load("correct.peptide.ratios.with",properties.env)
-      correct.protein.group <- .get.or.load("correct.peptide.ratios.with_protein.group",properties.env)
+      correct.protein.group <- if ( !is.null(property('correct.peptide.ratios.with_protein.group',properties.env)) ) {
+        .get.or.load("correct.peptide.ratios.with_protein.group",properties.env)
+      } else {
+        warning( '"correct.peptide.ratios.with_protein.group" property not found, ',
+                 'using the existing protein group' )
+        .get.or.load("protein.group.template",properties.env)
+      }
       ratios.opts[["before.summarize.f"]] <- function(...)
         correct.peptide.ratios(..., protein.quant.tbl=protein.quant.tbl,
                                protein.group.combined = correct.protein.group,

--- a/inst/report/properties.R
+++ b/inst/report/properties.R
@@ -210,6 +210,8 @@ ptm.info.f <- getPtmInfoFromNextprot
 ##  observed modified peptide ratios Needs to have the experimental
 ##  setup as the modified peptide experiment
 correct.peptide.ratios.with <- NULL
+## Protein groups to use with correct.peptide.ratios()
+correct.peptide.ratios.with_protein.group <- NULL
 
 ## The correlation between peptide and protein ratios defines the
 ## covariance


### PR DESCRIPTION
If "correct.peptide.ratios.with_protein.group" property is NULL, the default protein groups of 'ibspectra' object are used.
I don't fully understand the whole logic of ratio correction and classes structure, so I'm not sure if the proposed default behaviour is correct.
