### PR TITLE
Report "United" P-value

### DIFF
--- a/R/ptm-methods.R
+++ b/R/ptm-methods.R
@@ -287,7 +287,8 @@ writeHscoreData <- function(outfile,ids,massfile="defs.txt") {
              pep.prob <- round(pep.prob*round.to.frac)/round.to.frac
            prob[pep.pos] <- pep.prob
 
-           pep[prob>=0] <- paste0(pep[prob>=0],"(",prob[prob>=0],")")
+           prob_mask <- !is.na(prob) & prob>=0
+           pep[prob_mask] <- paste0(pep[prob_mask],"(",prob[prob_mask],")")
            paste0(pep,collapse="")
          },
          strsplit(peptide,""),


### PR DESCRIPTION
This pull requests add "united" P-value (i.e. proper P(X<=Y), w.r.t. X and Y distributions) to the isobar report. Plus the minor fix for checking that phosphoRS probabilities are not NA before injecting them into modified peptide sequence.

The patch also makes the significant changes in the report ("is_significant" column) based on the "united" P-value rather than on `p.value.rat` and `p.value.sample`.

So I suppose it would be nice to have the single P-value and the new way of defining the significance as it's more intuitive, but the PR should probably be tweaked to provide the backward compatibility in some elegant way.