### PR TITLE
PTM position match: handle NAs

### DIFF
--- a/R/ProteinGroup-class.R
+++ b/R/ProteinGroup-class.R
@@ -949,7 +949,8 @@ proteinGroup.as.concise.data.frame <-
                          sel <- ptm.info[,"isoform_ac"]==ac
                        else
                          sel <- ptm.info[,"isoform_ac"]==paste(ac,"-1",sep="")
-                       sel  <- sel  & ptm.info[,"position"]==pp
+                       sel <- sel & ptm.info[,"position"]==pp
+                       sel[is.na(sel)] <- FALSE
 
                        if (any(sel)) {
                          res <- apply(ptm.info[sel,],1,


### PR DESCRIPTION
Looks like NAs could creep into results <-> `ptm.info` matching (maybe because the identified ACs were not found in the protein database). To avoid an error at `any(sel)` all NAs are coverted to FALSE.   