### PR TITLE
Fixed a bug that prevented report creation in R 3.3.3

### DIFF
--- a/R/report-utils.R
+++ b/R/report-utils.R
@@ -502,9 +502,9 @@ property <- function(x, envir, null.ok=TRUE,class=NULL) {
 }
 
 .round.distr <- function(distr,digits) {
-  for (s in slotNames(param(distr))) 
-    if (s != "name" && is.numeric(slot(param(distr),s))) 
-      slot(distr@param,s) <- round(slot(param(distr),s),digits)
+  for (s in slotNames(distr@param)) 
+    if (s != "name" && is.numeric(slot(distr@param,s))) 
+      slot(distr@param,s) <- round(slot(distr@param,s),digits)
   distr
 }
 


### PR DESCRIPTION
This change was necessary for me to create a report using R 3.3.3.

The issue was that the `param()` method is not defined.